### PR TITLE
Added sonar.containerArgs argument so extra VM arguments could be passed to the internally started container

### DIFF
--- a/src/main/scripts/dev.build.xml
+++ b/src/main/scripts/dev.build.xml
@@ -376,6 +376,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
     </condition>
     <echo>Start JEE container, background mode: ${background}</echo>
 
+    <condition property="containerArgs" value="">
+      <not>
+        <isset property="containerArgs" />
+      </not>
+    </condition>
+
     <cargo containerId="${containerId}" action="start" wait="${sonar.wait}" id="${containerId}-${runtimeVersion}"
            output="${workDir}/sonar-${runtimeVersion}/logs/output.log"
            log="${workDir}/sonar-${runtimeVersion}/logs/cargo.log" timeout="900000">
@@ -383,7 +389,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
           installurl="${containerUrl}"/>
       <configuration type="standalone" home="${workDir}/${containerId}">
         <property name="cargo.jvmargs"
-                  value="-Xmx1024m -XX:MaxPermSize=128m -Dsonar.jdbc.url=${jdbcUrl} -Dsonar.jdbc.driverClassName=${jdbcDriver} -Dsonar.jdbc.username=${jdbcUsername} -Dsonar.jdbc.password=${jdbcPassword}"/>
+                  value="-Xmx1024m -XX:MaxPermSize=128m -Dsonar.jdbc.url=${jdbcUrl} -Dsonar.jdbc.driverClassName=${jdbcDriver} -Dsonar.jdbc.username=${jdbcUsername} -Dsonar.jdbc.password=${jdbcPassword} ${containerArgs}"/>
         <property name="cargo.servlet.port" value="9000"/>
         <property name="cargo.remote.username" value="admin"/>
         <property name="cargo.remote.password" value=""/>

--- a/src/main/scripts/dev.mojos.xml
+++ b/src/main/scripts/dev.mojos.xml
@@ -397,6 +397,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
           <defaultValue>tomcat6x</defaultValue>
         </parameter>
         <parameter>
+          <name>containerArgs</name>
+          <description>Optional VM arguments passed to the container</description>
+          <property>containerArgs</property>
+          <expression>${sonar.containerArgs}</expression>
+          <required>false</required>
+          <type>java.lang.String</type> 
+        </parameter>
+        <parameter>
           <name>mavenHome</name>
           <description>Maven home directory.</description>
           <property>mavenHome</property>


### PR DESCRIPTION
The argument is useful if someone wants to pass extra arguments to the container that is started internally. For example passing memory settings, javaagents (JRebel), etc.

Full disclosure: I work at ZeroTurnaround (www.zeroturnaround.com), the developers of JRebel and this development came from a customer request where someone wanted to use JRebel (specified as a javaagent to the VM) in his sonar development process using the sonar-dev-maven-plugin. However, I feel like this argument can be useful also in various other scenarios.
