### PR TITLE
Adding support for custom sonar.properties file

### DIFF
--- a/src/main/scripts/dev.build.xml
+++ b/src/main/scripts/dev.build.xml
@@ -295,10 +295,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
 
     <copy todir="${workDir}/sonar-${runtimeVersion}/conf/" overwrite="true" verbose="true" flatten="true">
       <resources>
-        <javaresource name="server/sonar.properties"/>
         <javaresource name="server/wrapper.conf"/>
       </resources>
     </copy>
+    <available property="custom.properties" file="${customProperties}"/>
+    <if>
+      <isset property="custom.properties"/>
+      <then>
+        <copy file="${customProperties}" todir="${workDir}/sonar-${runtimeVersion}/conf/" overwrite="true" verbose="true" flatten="true" />
+      </then>
+      <else>
+        <copy todir="${workDir}/sonar-${runtimeVersion}/conf/" overwrite="true" verbose="true" flatten="true">
+          <resources>
+            <javaresource name="server/sonar.properties"/>
+          </resources>
+        </copy>
+      </else>
+    </if>
+
 
     <available property="has.extensions" file="${extensionsDir}"/>
     <antcall target="copy-extensions"/>

--- a/src/main/scripts/dev.mojos.xml
+++ b/src/main/scripts/dev.mojos.xml
@@ -188,6 +188,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
           <type>java.io.File</type>
           <defaultValue>${maven.home}</defaultValue>
         </parameter>
+        <parameter>
+          <name>customProperties</name>
+          <description>Path to custom sonar properties file.</description>
+          <property>customProperties</property>
+          <expression>${sonar.customProperties}</expression>
+          <required>false</required>
+          <type>java.lang.String</type>
+        </parameter>
 
       </parameters>
     </mojo>


### PR DESCRIPTION
If ```sonar.customProperties``` is set and pointing to an existing file, it will be used as sonar.properties.
Use ```server/sonar.properties``` otherwise.